### PR TITLE
Update README for YabHereWeGo features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
-# Irigo Lines Map
+# YabHereWeGo
 
-Cette page web affiche une carte interactive du réseau Irigo grâce à la bibliothèque Leaflet.
+Cette page web affiche une carte interactive du réseau Irigo grâce à la bibliothèque Leaflet. Elle est accessible à l'adresse [yabrich.github.io](https://yabrich.github.io).
+
+## Fonctionnalités
+
+- **Localisation** : bouton *Me localiser* pour centrer la carte sur votre position.
+- **Mode sombre/clair** : le fond de carte bascule automatiquement selon l'heure (lever/coucher du soleil).
+- **Affichage détaillé des véhicules** : en cliquant sur un véhicule, vous obtenez son numéro de parc, la ligne, le prochain arrêt et la destination.
+  ![Détail véhicule](./images/vehicle_details_placeholder.png)
+- **Suivi de véhicule** : depuis la fenêtre d'information d'un véhicule, cliquez sur *Suivre ce véhicule* pour que la carte reste centrée sur lui.
+- **Filtre des lignes** : choisissez les lignes à afficher. Les lignes sélectionnées sont mémorisées. Les lignes disponibles vont du tramway **A**, **B**, **C** aux bus **01** à **42**.
 
 ## Fichiers principaux
 
@@ -8,9 +17,14 @@ Cette page web affiche une carte interactive du réseau Irigo grâce à la bibli
 - `script.js` : logique de la carte (filtrage des lignes, localisations, récupération des véhicules...).
 - `irigo_gtfs_lines.geojson` : géométries des lignes du réseau.
 - `horaires-theoriques-et-arrets-du-reseau-irigo-gtfs.json` : arrêts et informations GTFS.
+- `irigo_trips.xlsx` : tableau des voyages du réseau extrait du GTFS (lignes, arrêt départ, destination, horaires).
 
-## Utilisation locale
+## Utilisation
 
-Ouvrez simplement `index.html` dans votre navigateur. Aucun serveur spécifique n'est nécessaire.
+Le site s'utilise directement via [yabrich.github.io](https://yabrich.github.io). Pour un usage hors ligne, ouvrez simplement `index.html` dans votre navigateur (aucun serveur spécifique n'est nécessaire).
 
 Cette page télécharge régulièrement la position des véhicules via l'API externe `https://web-production-c4b0.up.railway.app/vehicules-irigo.json` (toutes les 30 s environ). Une connexion Internet est donc requise pour cette fonctionnalité ainsi que pour charger les tuiles de carte.
+
+## Illustration
+
+![Aperçu de la carte](./images/app_placeholder.png)


### PR DESCRIPTION
## Summary
- rename project to **YabHereWeGo**
- document localisation button, dark/light mode, vehicle details and tracking
- mention saved filters with available lines and website usage
- add placeholders for screenshots and illustration
- document **irigo_trips.xlsx** data file

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845b4d4c4fc832bab1aa7074e781cd8