### PR TITLE
Add countdown for vehicle update

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,18 @@
       transform: translateY(-1px);
     }
 
+    #update_timer {
+      position: absolute;
+      bottom: 40px;
+      left: 10px;
+      z-index: 1000;
+      background: rgba(255,255,255,0.9);
+      padding: 6px 8px;
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 14px;
+      border-radius: 4px;
+    }
+
     #track_hint {
       position: absolute;
       bottom: 10px;
@@ -111,6 +123,7 @@
     body.dark-mode #locate_btn:hover {
       background-color: #444;
     }
+    body.dark-mode #update_timer,
     body.dark-mode #track_hint {
       background: rgba(40, 40, 40, 0.9);
       color: #ddd;
@@ -175,6 +188,7 @@
   <div id="filter-list"></div>
 </div>
   <button id="locate_btn">Me localiser</button>
+  <div id="update_timer"></div>
   <div id="track_hint">Cliquez sur un véhicule pour le suivre</div>
 
   <!-- SheetJS-->

--- a/script.js
+++ b/script.js
@@ -312,7 +312,7 @@ Promise.all([
     // Sauvegarde dans localStorage
     localStorage.setItem('selectedRoutes', JSON.stringify(Array.from(selectedRoutes)));
     updateLines();
-    chargerVehicules();
+    updateVehicles();
   });
   filterList.appendChild(toggleBtn);
 
@@ -348,7 +348,7 @@ Promise.all([
         // Sauvegarde dans localStorage
         localStorage.setItem('selectedRoutes', JSON.stringify(Array.from(selectedRoutes)));
         updateLines();
-        chargerVehicules();
+        updateVehicles();
       });
 
       wrapper.append(chk, lbl);
@@ -372,8 +372,8 @@ Promise.all([
   // Initial render
   updateLines();
   initStopsLayer();
-  chargerVehicules();
-  setInterval(chargerVehicules, 30000);
+  updateVehicles();
+  setInterval(updateVehicles, UPDATE_INTERVAL_MS);
 })
 .catch(err => console.error('Échec chargement initial :', err));
 
@@ -449,6 +449,20 @@ function initStopsLayer() {
 // ==================================
 // 9. AFFICHAGE DES VÉHICULES
 // ==================================
+const UPDATE_INTERVAL_MS = 30000;
+const timerEl = document.getElementById('update_timer');
+let remainingTime = UPDATE_INTERVAL_MS / 1000;
+function updateTimerDisplay() {
+  timerEl.textContent = `Mise à jour dans ${remainingTime}s`;
+}
+updateTimerDisplay();
+setInterval(() => {
+  if (remainingTime > 0) {
+    remainingTime--;
+    updateTimerDisplay();
+  }
+}, 1000);
+
 let markers = [];
 async function chargerVehicules() {
   markers.forEach(m => map.removeLayer(m));
@@ -513,4 +527,10 @@ async function chargerVehicules() {
   } catch (e) {
     console.warn('Impossible de charger les véhicules :', e);
   }
+}
+
+async function updateVehicles() {
+  remainingTime = UPDATE_INTERVAL_MS / 1000;
+  updateTimerDisplay();
+  await chargerVehicules();
 }


### PR DESCRIPTION
## Summary
- Display countdown timer for next vehicle position refresh
- Reset timer whenever positions reload and handle dark mode styling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897bb7d4b68832b9f6a677fe1705969